### PR TITLE
Add a gitattributes file to highlight .ro files as ruby on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ro linguist-language=ruby

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.ro linguist-language=ruby
+*.ro linguist-language=Ruby


### PR DESCRIPTION
GitHub uses linguist for language detection, which supports `.gitattributes` files for hinting. https://github.com/github/linguist#using-gitattributes

This should make `*.ro` files show up syntax highlighted with the Ruby parser on GitHub.