### PR TITLE
Fix instruction set overwriting issue

### DIFF
--- a/rooby.go
+++ b/rooby.go
@@ -42,14 +42,14 @@ func main() {
 		bytecodes := g.GenerateByteCode(program)
 
 		if !*compileOptionPtr {
-			execBytecode(bytecodes, dir)
+			execBytecode(bytecodes, dir, filepath)
 			return
 		}
 
 		writeByteCode(bytecodes, dir, filename)
 	case "robc":
 		bytecodes := string(file)
-		execBytecode(bytecodes, dir)
+		execBytecode(bytecodes, dir, filepath)
 	default:
 		fmt.Printf("Unknown file extension: %s", fileExt)
 	}
@@ -65,9 +65,9 @@ func writeByteCode(bytecodes, dir, filename string) {
 	f.WriteString(bytecodes)
 }
 
-func execBytecode(bytecodes, fileDir string) {
+func execBytecode(bytecodes, fileDir, filepath string) {
 	v := vm.New(fileDir)
-	v.ExecBytecodes(bytecodes)
+	v.ExecBytecodes(bytecodes, filepath)
 }
 
 func check(e error) {

--- a/rooby_test.go
+++ b/rooby_test.go
@@ -5,18 +5,18 @@ import (
 	"github.com/rooby-lang/rooby/parser"
 	"github.com/rooby-lang/rooby/vm"
 	"io/ioutil"
-	"testing"
-	"runtime"
 	"path"
+	"runtime"
+	"testing"
 )
 
-func TestRequireRelative(t *testing.T) {
-	filename := "main.ro"
-	fileDir := "require_test"
-	result := execFile(fileDir, filename)
-
-	testIntegerObject(t, result, 50)
-}
+//func TestRequireRelative(t *testing.T) {
+//	filename := "main.ro"
+//	fileDir := "require_test"
+//	result := execFile(fileDir, filename)
+//
+//	testIntegerObject(t, result, 50)
+//}
 
 func execFile(fileDir, filename string) vm.Object {
 	_, currentPath, _, _ := runtime.Caller(0)
@@ -37,7 +37,7 @@ func execFile(fileDir, filename string) vm.Object {
 	bytecodes := g.GenerateByteCode(program)
 
 	v := vm.New(dir)
-	v.ExecBytecodes(bytecodes)
+	v.ExecBytecodes(bytecodes, filepath)
 	return v.GetExecResult()
 }
 

--- a/rooby_test.go
+++ b/rooby_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 )
 
-//func TestRequireRelative(t *testing.T) {
-//	filename := "main.ro"
-//	fileDir := "require_test"
-//	result := execFile(fileDir, filename)
-//
-//	testIntegerObject(t, result, 50)
-//}
+func TestRequireRelative(t *testing.T) {
+	filename := "main.ro"
+	fileDir := "require_test"
+	result := execFile(fileDir, filename)
+
+	testIntegerObject(t, result, 160)
+}
 
 func execFile(fileDir, filename string) vm.Object {
 	_, currentPath, _, _ := runtime.Caller(0)

--- a/test_fixtures/require_test/bar.ro
+++ b/test_fixtures/require_test/bar.ro
@@ -2,4 +2,8 @@ class Bar
   def self.foo
     yield(10)
   end
+
+  def self.baz
+    10
+  end
 end

--- a/test_fixtures/require_test/foo.ro
+++ b/test_fixtures/require_test/foo.ro
@@ -6,4 +6,8 @@ class Foo
       x * ten
     end
   end
+
+  def self.baz
+    yield(100)
+  end
 end

--- a/test_fixtures/require_test/main.ro
+++ b/test_fixtures/require_test/main.ro
@@ -1,5 +1,7 @@
 require_relative "./foo"
 
+fifty = Foo.bar(5)
+
 Foo.baz do |hundred|
-  hundred + Foo.bar(5)
+  hundred + fifty + Bar.baz
 end

--- a/test_fixtures/require_test/main.ro
+++ b/test_fixtures/require_test/main.ro
@@ -1,3 +1,5 @@
 require_relative "./foo"
 
-Foo.bar(5)
+Foo.baz do |hundred|
+  hundred + Foo.bar(5)
+end

--- a/vm/bytecode_parser.go
+++ b/vm/bytecode_parser.go
@@ -17,15 +17,16 @@ type bytecodeParser struct {
 	labelTable map[labelType]map[string][]*instructionSet
 	vm         *VM
 	file       string
+	blockTable map[string]*instructionSet
 }
 
 // newBytecodeParser initializes bytecodeParser and its label table then returns it
 func newBytecodeParser(file string) *bytecodeParser {
 	p := &bytecodeParser{file: file}
+	p.blockTable = make(map[string]*instructionSet)
 	p.labelTable = map[labelType]map[string][]*instructionSet{
 		LabelDef:      make(map[string][]*instructionSet),
 		LabelDefClass: make(map[string][]*instructionSet),
-		Block:         make(map[string][]*instructionSet),
 		Program:       make(map[string][]*instructionSet),
 	}
 
@@ -85,6 +86,11 @@ func (p *bytecodeParser) setLabel(is *instructionSet, name string) {
 
 	l = &label{name: name, Type: labelType}
 	is.label = l
+
+	if labelType == Block {
+		p.blockTable[labelName] = is
+		return
+	}
 	p.labelTable[labelType][labelName] = append(p.labelTable[labelType][labelName], is)
 }
 

--- a/vm/bytecode_parser.go
+++ b/vm/bytecode_parser.go
@@ -16,11 +16,12 @@ type bytecodeParser struct {
 	line       int
 	labelTable map[labelType]map[string][]*instructionSet
 	vm         *VM
+	file       string
 }
 
 // newBytecodeParser initializes bytecodeParser and its label table then returns it
-func newBytecodeParser() *bytecodeParser {
-	p := &bytecodeParser{}
+func newBytecodeParser(file string) *bytecodeParser {
+	p := &bytecodeParser{file: file}
 	p.labelTable = map[labelType]map[string][]*instructionSet{
 		LabelDef:      make(map[string][]*instructionSet),
 		LabelDefClass: make(map[string][]*instructionSet),
@@ -42,7 +43,7 @@ func (p *bytecodeParser) parseBytecode(bytecodes string) []*instructionSet {
 }
 
 func (p *bytecodeParser) parseSection(iss []*instructionSet, bytecodesByLine []string) {
-	is := &instructionSet{}
+	is := &instructionSet{file: p.file}
 	count := 0
 
 	// First line is label
@@ -113,7 +114,7 @@ func (p *bytecodeParser) parseInstruction(is *instructionSet, line string) {
 		program := parser.BuildAST(file)
 		g := bytecode.NewGenerator(program)
 		bytecodes := g.GenerateByteCode(program)
-		p.vm.ExecBytecodes(bytecodes)
+		p.vm.ExecBytecodes(bytecodes, filepath)
 		return
 	} else if len(tokens) > 2 {
 		rawParams = tokens[2:]

--- a/vm/evaluation_test.go
+++ b/vm/evaluation_test.go
@@ -774,7 +774,7 @@ func TestMethodCallWithBlockArgument(t *testing.T) {
 
 		f.bar(10) do |x|
                   y = x + y
-                end
+		end
 
 		y
 		`, 20},

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -36,7 +36,7 @@ var labelTypes = map[string]labelType{
 type instructionSet struct {
 	label        *label
 	instructions []*instruction
-	file         string
+	filename     filename
 }
 
 type operationType string
@@ -246,7 +246,7 @@ var builtInActions = map[operationType]*action{
 		operation: func(vm *VM, cf *callFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			methodName := vm.stack.pop().Target.(*StringObject).Value
-			is, _ := vm.getMethodIS(methodName, cf.instructionSet.file)
+			is, _ := vm.getMethodIS(methodName, cf.instructionSet.filename)
 			method := &Method{Name: methodName, argc: argCount, instructionSet: is}
 
 			v := vm.stack.pop().Target
@@ -265,7 +265,7 @@ var builtInActions = map[operationType]*action{
 		operation: func(vm *VM, cf *callFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			methodName := vm.stack.pop().Target.(*StringObject).Value
-			is, _ := vm.getMethodIS(methodName, cf.instructionSet.file)
+			is, _ := vm.getMethodIS(methodName, cf.instructionSet.filename)
 			method := &Method{Name: methodName, argc: argCount, instructionSet: is}
 
 			v := vm.stack.pop().Target
@@ -287,7 +287,7 @@ var builtInActions = map[operationType]*action{
 			classPr := &Pointer{Target: class}
 			vm.constants[class.Name] = classPr
 
-			is, ok := vm.getClassIS(class.Name, cf.instructionSet.file)
+			is, ok := vm.getClassIS(class.Name, cf.instructionSet.filename)
 
 			if !ok {
 				panic(fmt.Sprintf("Can't find class %s's instructions", class.Name))
@@ -355,7 +355,7 @@ var builtInActions = map[operationType]*action{
 			var blockFrame *callFrame
 
 			if hasBlock {
-				block, ok := vm.getBlock(blockName, cf.instructionSet.file)
+				block, ok := vm.getBlock(blockName, cf.instructionSet.filename)
 
 				if !ok {
 					panic(fmt.Sprintf("Can't find block %s", blockName))

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -246,7 +246,7 @@ var builtInActions = map[operationType]*action{
 		operation: func(vm *VM, cf *callFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			methodName := vm.stack.pop().Target.(*StringObject).Value
-			is, _ := vm.getMethodIS(methodName)
+			is, _ := vm.getMethodIS(methodName, cf.instructionSet.file)
 			method := &Method{Name: methodName, argc: argCount, instructionSet: is}
 
 			v := vm.stack.pop().Target
@@ -265,7 +265,7 @@ var builtInActions = map[operationType]*action{
 		operation: func(vm *VM, cf *callFrame, args ...interface{}) {
 			argCount := args[0].(int)
 			methodName := vm.stack.pop().Target.(*StringObject).Value
-			is, _ := vm.getMethodIS(methodName)
+			is, _ := vm.getMethodIS(methodName, cf.instructionSet.file)
 			method := &Method{Name: methodName, argc: argCount, instructionSet: is}
 
 			v := vm.stack.pop().Target
@@ -287,7 +287,7 @@ var builtInActions = map[operationType]*action{
 			classPr := &Pointer{Target: class}
 			vm.constants[class.Name] = classPr
 
-			is, ok := vm.getClassIS(class.Name)
+			is, ok := vm.getClassIS(class.Name, cf.instructionSet.file)
 
 			if !ok {
 				panic(fmt.Sprintf("Can't find class %s's instructions", class.Name))
@@ -355,7 +355,7 @@ var builtInActions = map[operationType]*action{
 			var blockFrame *callFrame
 
 			if hasBlock {
-				block, ok := vm.getBlock(blockName)
+				block, ok := vm.getBlock(blockName, cf.instructionSet.file)
 
 				if !ok {
 					panic(fmt.Sprintf("Can't find block %s", blockName))

--- a/vm/instruction.go
+++ b/vm/instruction.go
@@ -36,6 +36,7 @@ var labelTypes = map[string]labelType{
 type instructionSet struct {
 	label        *label
 	instructions []*instruction
+	file         string
 }
 
 type operationType string

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -62,8 +62,8 @@ func New(fileDir string) *VM {
 }
 
 // ExecBytecodes accepts a sequence of bytecodes and use vm to evaluate them.
-func (vm *VM) ExecBytecodes(bytecodes string) {
-	p := newBytecodeParser()
+func (vm *VM) ExecBytecodes(bytecodes, filepath string) {
+	p := newBytecodeParser(filepath)
 	p.vm = vm
 	p.parseBytecode(bytecodes)
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -19,19 +19,27 @@ type VM struct {
 	// a map holds pointers of constants
 	constants map[string]*Pointer
 	// a map holds different types of label tables
-	labelTables map[labelType]map[string][]*instructionSet
+	isTables map[labelType]isTable
 	// method instruction set table
-	methodISTable map[string]*isIndexTable
+	methodISIndexTables map[filename]*isIndexTable
 	// class instruction set table
-	classISTable map[string]*isIndexTable
+	classISIndexTables map[filename]*isIndexTable
 	// block instruction set table
-	blockTables map[string]map[string]*instructionSet
+	blockTables map[filename]map[string]*instructionSet
 
 	fileDir string
 }
 
 type isIndexTable struct {
 	Data map[string]int
+}
+
+type isTable map[string][]*instructionSet
+
+type filename string
+
+func newISIndexTable() *isIndexTable {
+	return &isIndexTable{Data: make(map[string]int)}
 }
 
 type stack struct {
@@ -48,25 +56,25 @@ func New(fileDir string) *VM {
 	cfs.vm = vm
 
 	vm.initConstants()
-	vm.methodISTable = map[string]*isIndexTable{
-		fileDir: {Data: make(map[string]int)},
+	vm.methodISIndexTables = map[filename]*isIndexTable{
+		filename(fileDir): newISIndexTable(),
 	}
-	vm.classISTable = map[string]*isIndexTable{
-		fileDir: {Data: make(map[string]int)},
+	vm.classISIndexTables = map[filename]*isIndexTable{
+		filename(fileDir): newISIndexTable(),
 	}
-	vm.blockTables = make(map[string]map[string]*instructionSet)
-	vm.labelTables = map[labelType]map[string][]*instructionSet{
-		LabelDef:      make(map[string][]*instructionSet),
-		LabelDefClass: make(map[string][]*instructionSet),
-		Program:       make(map[string][]*instructionSet),
+	vm.blockTables = make(map[filename]map[string]*instructionSet)
+	vm.isTables = map[labelType]isTable{
+		LabelDef:      make(isTable),
+		LabelDefClass: make(isTable),
 	}
 	vm.fileDir = fileDir
 	return vm
 }
 
 // ExecBytecodes accepts a sequence of bytecodes and use vm to evaluate them.
-func (vm *VM) ExecBytecodes(bytecodes, filepath string) {
-	p := newBytecodeParser(filepath)
+func (vm *VM) ExecBytecodes(bytecodes, fn string) {
+	filename := filename(fn)
+	p := newBytecodeParser(filename)
 	p.vm = vm
 	p.parseBytecode(bytecodes)
 
@@ -74,14 +82,15 @@ func (vm *VM) ExecBytecodes(bytecodes, filepath string) {
 	// TODO: Find more efficient way to do this.
 	for labelType, table := range p.labelTable {
 		for labelName, is := range table {
-			vm.labelTables[labelType][labelName] = is
+			vm.isTables[labelType][labelName] = is
 		}
 	}
-	vm.blockTables[p.file] = p.blockTable
-	vm.classISTable[filepath] = &isIndexTable{Data: make(map[string]int)}
-	vm.methodISTable[filepath] = &isIndexTable{Data: make(map[string]int)}
 
-	cf := newCallFrame(vm.labelTables[Program]["ProgramStart"][0])
+	vm.blockTables[p.filename] = p.blockTable
+	vm.classISIndexTables[filename] = newISIndexTable()
+	vm.methodISIndexTables[filename] = newISIndexTable()
+
+	cf := newCallFrame(p.program)
 	cf.self = mainObj
 	vm.callFrameStack.push(cf)
 	vm.start()
@@ -135,10 +144,10 @@ func (vm *VM) execInstruction(cf *callFrame, i *instruction) {
 	//fmt.Println(vm.stack.inspect())
 }
 
-func (vm *VM) getBlock(name, file string) (*instructionSet, bool) {
+func (vm *VM) getBlock(name string, filename filename) (*instructionSet, bool) {
 	// The "name" here is actually an index from label
 	// for example <Block:1>'s name is "1"
-	is, ok := vm.blockTables[file][name]
+	is, ok := vm.blockTables[filename][name]
 
 	if !ok {
 		return nil, false
@@ -147,29 +156,29 @@ func (vm *VM) getBlock(name, file string) (*instructionSet, bool) {
 	return is, ok
 }
 
-func (vm *VM) getMethodIS(name, file string) (*instructionSet, bool) {
-	iss, ok := vm.labelTables[LabelDef][name]
+func (vm *VM) getMethodIS(name string, filename filename) (*instructionSet, bool) {
+	iss, ok := vm.isTables[LabelDef][name]
 
 	if !ok {
 		return nil, false
 	}
 
-	is := iss[vm.methodISTable[file].Data[name]]
+	is := iss[vm.methodISIndexTables[filename].Data[name]]
 
-	vm.methodISTable[file].Data[name]++
+	vm.methodISIndexTables[filename].Data[name]++
 	return is, ok
 }
 
-func (vm *VM) getClassIS(name, file string) (*instructionSet, bool) {
-	iss, ok := vm.labelTables[LabelDefClass][name]
+func (vm *VM) getClassIS(name string, filename filename) (*instructionSet, bool) {
+	iss, ok := vm.isTables[LabelDefClass][name]
 
 	if !ok {
 		return nil, false
 	}
 
-	is := iss[vm.classISTable[file].Data[name]]
+	is := iss[vm.classISIndexTables[filename].Data[name]]
 
-	vm.classISTable[file].Data[name]++
+	vm.classISIndexTables[filename].Data[name]++
 	return is, ok
 }
 

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -396,7 +396,7 @@ func checkParserErrors(t *testing.T, p *parser.Parser) {
 
 func testExec(bytecodes string) Object {
 	v := New("./")
-	v.ExecBytecodes(bytecodes)
+	v.ExecBytecodes(bytecodes, "./")
 
 	return v.stack.top().Target
 }


### PR DESCRIPTION
When requiring files, later file's instruction set will overwrite previous file's instruction set. This will make some issues when executing blocks. This PR is to fix this issue.