### PR TITLE
Add new methods to array

### DIFF
--- a/vm/array.go
+++ b/vm/array.go
@@ -356,18 +356,23 @@ var builtinArrayMethods = []*BuiltInMethod{
 				findBoolean, findIsBoolean := arg.(*BooleanObject)
 
 				for i := 0; i < len(arr.Elements); i++ {
-					elInt, isInt := arr.Elements[i].(*IntegerObject)
-					if isInt && findIsInt && elInt.Value == findInt.Value {
-						count++
-					}
-					elString, isString := arr.Elements[i].(*StringObject)
-					if isString && findIsString && elString.Value == findString.Value {
-						count++
-					}
-
-					elBoolean, isBoolean := arr.Elements[i].(*BooleanObject)
-					if isBoolean && findIsBoolean && elBoolean.Value == findBoolean.Value {
-						count++
+					el := arr.Elements[i]
+					switch el.(type) {
+					case *IntegerObject:
+						elInt := el.(*IntegerObject)
+						if findIsInt && findInt.equal(elInt) {
+							count++
+						}
+					case *StringObject:
+						elString := el.(*StringObject)
+						if findIsString && findString.equal(elString) {
+							count++
+						}
+					case *BooleanObject:
+						elBoolean := el.(*BooleanObject)
+						if findIsBoolean && findBoolean.equal(elBoolean) {
+							count++
+						}
 					}
 				}
 
@@ -379,11 +384,6 @@ var builtinArrayMethods = []*BuiltInMethod{
 	{
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
-
-				if len(args) > 1 {
-					return newError("Expect one argument. got=%d", len(args))
-				}
-
 				arr := receiver.(*ArrayObject)
 				rotArr := initializeArray(arr.Elements)
 

--- a/vm/array.go
+++ b/vm/array.go
@@ -247,4 +247,62 @@ var builtinArrayMethods = []*BuiltInMethod{
 		},
 		Name: "select",
 	},
+	{
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
+				i := args[0]
+				index, ok := i.(*IntegerObject)
+
+				if !ok {
+					return newError("Expect index argument to be Integer. got=%T", i)
+				}
+
+				arr := receiver.(*ArrayObject)
+
+				if len(arr.Elements) == 0 {
+					return NULL
+				}
+
+				if int(index.Value) >= len(arr.Elements) {
+					return newError("Index out of range")
+				}
+
+				return arr.Elements[index.Value]
+			}
+		},
+		Name: "at",
+	},
+	{
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
+				arr := receiver.(*ArrayObject)
+				arr.Elements = []Object{}
+
+				return arr
+			}
+		},
+		Name: "clear",
+	},
+	{
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
+				arr := receiver.(*ArrayObject)
+
+				for _, arg := range args {
+					addAr, ok := arg.(*ArrayObject)
+
+					if !ok {
+						return newError("Expect argument to be Array. got=%T", arg)
+					}
+
+					for _, el := range addAr.Elements {
+						arr.Elements = append(arr.Elements, el)
+					}
+				}
+
+				return arr
+			}
+		},
+		Name: "concat",
+	},
 }

--- a/vm/array.go
+++ b/vm/array.go
@@ -65,6 +65,13 @@ func (a *ArrayObject) push(objs []Object) *ArrayObject {
 	return a
 }
 
+// shift removes the first element in the array and returns it
+func (a *ArrayObject) shift() Object {
+	value := a.Elements[0]
+	a.Elements = a.Elements[1:]
+	return value
+}
+
 // initializeArray returns an array that contains given objects
 func initializeArray(elements []Object) *ArrayObject {
 	return &ArrayObject{Elements: elements, Class: arrayClass}
@@ -191,6 +198,19 @@ var builtinArrayMethods = []*BuiltInMethod{
 	{
 		Fn: func(receiver Object) builtinMethodBody {
 			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
+				if len(args) != 0 {
+					return newError("Expect 0 argument. got=%d", len(args))
+				}
+
+				arr := receiver.(*ArrayObject)
+				return arr.shift()
+			}
+		},
+		Name: "shift",
+	},
+	{
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
 				arr := receiver.(*ArrayObject)
 
 				if blockFrame == nil {
@@ -304,5 +324,87 @@ var builtinArrayMethods = []*BuiltInMethod{
 			}
 		},
 		Name: "concat",
+	},
+	{
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
+				arr := receiver.(*ArrayObject)
+				var count int
+
+				if blockFrame != nil {
+					for _, obj := range arr.Elements {
+						result := builtInMethodYield(vm, blockFrame, obj)
+						if result.Target.(*BooleanObject).Value {
+							count++
+						}
+					}
+
+					return initilaizeInteger(count)
+				}
+
+				if len(args) > 1 {
+					return newError("Expect one argument. got=%d", len(args))
+				}
+
+				if len(args) == 0 {
+					return initilaizeInteger(len(arr.Elements))
+				}
+
+				arg := args[0]
+				findInt, findIsInt := arg.(*IntegerObject)
+				findString, findIsString := arg.(*StringObject)
+				findBoolean, findIsBoolean := arg.(*BooleanObject)
+
+				for i := 0; i < len(arr.Elements); i++ {
+					elInt, isInt := arr.Elements[i].(*IntegerObject)
+					if isInt && findIsInt && elInt.Value == findInt.Value {
+						count++
+					}
+					elString, isString := arr.Elements[i].(*StringObject)
+					if isString && findIsString && elString.Value == findString.Value {
+						count++
+					}
+
+					elBoolean, isBoolean := arr.Elements[i].(*BooleanObject)
+					if isBoolean && findIsBoolean && elBoolean.Value == findBoolean.Value {
+						count++
+					}
+				}
+
+				return initilaizeInteger(count)
+			}
+		},
+		Name: "count",
+	},
+	{
+		Fn: func(receiver Object) builtinMethodBody {
+			return func(vm *VM, args []Object, blockFrame *callFrame) Object {
+
+				if len(args) > 1 {
+					return newError("Expect one argument. got=%d", len(args))
+				}
+
+				arr := receiver.(*ArrayObject)
+				rotArr := initializeArray(arr.Elements)
+
+				rotate := 1
+
+				if len(args) != 0 {
+					arg, ok := args[0].(*IntegerObject)
+					if !ok {
+						return newError("Expect index argument to be Integer. got=%T", args[0])
+					}
+					rotate = arg.Value
+				}
+
+				for i := 0; i < rotate; i++ {
+					el := rotArr.shift()
+					rotArr.push([]Object{el})
+				}
+
+				return rotArr
+			}
+		},
+		Name: "rotate",
 	},
 }

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -62,7 +62,9 @@ func TestShiftMethod(t *testing.T) {
 
 	testArrayObject(t, array, second)
 	testIntegerObject(t, first, 1)
+}
 
+func TestShiftMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
 		expected *Error
@@ -315,7 +317,9 @@ func TestConcatMethod(t *testing.T) {
 		evaluated := testEval(t, tt.input)
 		testArrayObject(t, evaluated, tt.expected)
 	}
+}
 
+func TestConcatMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
 		expected *Error
@@ -385,7 +389,9 @@ func TestCountMethod(t *testing.T) {
 		evaluated := testEval(t, tt.input)
 		testIntegerObject(t, evaluated, tt.expected.Value)
 	}
+}
 
+func TestCountMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
 		expected *Error
@@ -427,15 +433,13 @@ func TestRotateMethod(t *testing.T) {
 		evaluated := testEval(t, tt.input)
 		testArrayObject(t, evaluated, tt.expected)
 	}
+}
 
+func TestRotateMethodFail(t *testing.T) {
 	testsFail := []struct {
 		input    string
 		expected *Error
 	}{
-		{`
-		a = [1, 2]
-		a.rotate(3, 3, 4, 5)
-		`, newError("Expect one argument. got=4")},
 		{`
 		a = [1, 2]
 		a.rotate("a")

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -62,6 +62,27 @@ func TestShiftMethod(t *testing.T) {
 
 	testArrayObject(t, array, second)
 	testIntegerObject(t, first, 1)
+
+	testsFail := []struct {
+		input    string
+		expected *Error
+	}{
+		{`
+		a = [1, 2]
+		a.shift(3, 3, 4, 5)
+		`, newError("Expect 0 argument. got=4")},
+	}
+
+	for _, tt := range testsFail {
+		evaluated := testEval(t, tt.input)
+		err, ok := evaluated.(*Error)
+		if !ok {
+			t.Errorf("Expect error. got=%T (%+v)", err, err)
+		}
+		if err.Message != tt.expected.Message {
+			t.Errorf("Expect error message \"%s\". got=\"%s\"", err.Message, tt.expected.Message)
+		}
+	}
 }
 
 func TestEvalArrayExpression(t *testing.T) {
@@ -330,6 +351,10 @@ func TestCountMethod(t *testing.T) {
 		a = [1, 2]
 		a.count
 		`, initilaizeInteger(2)},
+		{`
+		a = [1, 2]
+		a.count(1)
+		`, initilaizeInteger(1)},
 		{`
 		a = ["a", "bb", "c", "db", "bb", 2]
 		a.count("bb")

--- a/vm/array_test.go
+++ b/vm/array_test.go
@@ -92,7 +92,6 @@ func TestEvalArrayIndex(t *testing.T) {
 			a = [1, "a", 10, 5]
 			a[2] = a[1]
 			a[2]
-
 		`, "a"},
 		{`
 			a = []
@@ -108,6 +107,29 @@ func TestEvalArrayIndex(t *testing.T) {
 			a = [1, 2 ,3 ,5 , 10]
 			a[0] = a[1] + a[2] + a[3] * a[4]
 			a[0]
+		`, 55},
+		{`
+			[].at(1)
+		`, nil},
+		{`
+			[1, 2, 10, 5].at(2)
+		`, int64(10)},
+		{`
+			[1, "a", 10, 5].at(1)
+		`, "a"},
+		{`
+			a = [1, "a", 10, 5]
+			a.at(0)
+		`, 1},
+		{`
+			a = [1, "a", 10, 5]
+			a[2] = a.at(1)
+			a[2]
+		`, "a"},
+		{`
+			a = [1, 2, 3, 5, 10]
+			a[0] = a.at(1) + a.at(2) + a.at(3) * a.at(4)
+			a.at(0)
 		`, 55},
 	}
 
@@ -214,6 +236,77 @@ func TestSelectMethod(t *testing.T) {
 	for _, tt := range tests {
 		evaluated := testEval(t, tt.input)
 		testArrayObject(t, evaluated, tt.expected)
+	}
+}
+
+func TestClearMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *ArrayObject
+	}{
+		{`
+		a = [1, 2, 3]
+		a.clear
+		`, initializeArray([]Object{})},
+		{`
+		a = []
+		a.clear
+		`, initializeArray([]Object{})},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(t, tt.input)
+		testArrayObject(t, evaluated, tt.expected)
+	}
+}
+
+func TestConcatMethod(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected *ArrayObject
+	}{
+		{`
+		a = [1, 2]
+		a.concat([3], [4])
+		`, initializeArray([]Object{initilaizeInteger(1), initilaizeInteger(2), initilaizeInteger(3), initilaizeInteger(4)})},
+		{`
+		a = []
+		a.concat([1], [2], ["a", "b"], [3], [4])
+		`, initializeArray([]Object{initilaizeInteger(1), initilaizeInteger(2), initializeString("a"), initializeString("b"), initilaizeInteger(3), initilaizeInteger(4)})},
+		{`
+		a = [1, 2]
+		a.concat()
+		`, initializeArray([]Object{initilaizeInteger(1), initilaizeInteger(2)})},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(t, tt.input)
+		testArrayObject(t, evaluated, tt.expected)
+	}
+
+	testsFail := []struct {
+		input    string
+		expected *Error
+	}{
+		{`
+		a = [1, 2]
+		a.concat(3)
+		`, newError("Expect argument to be Array. got=*vm.IntegerObject")},
+		{`
+		a = []
+		a.concat("a")
+		`, newError("Expect argument to be Array. got=*vm.StringObject")},
+	}
+
+	for _, tt := range testsFail {
+		evaluated := testEval(t, tt.input)
+		err, ok := evaluated.(*Error)
+		if !ok {
+			t.Errorf("Expect error. got=%T (%+v)", err, err)
+		}
+		if err.Message != tt.expected.Message {
+			t.Errorf("Expect error message \"%s\". got=\"%s\"", err.Message, tt.expected.Message)
+		}
 	}
 }
 

--- a/vm/boolean.go
+++ b/vm/boolean.go
@@ -39,6 +39,10 @@ func (b *BooleanObject) returnClass() Class {
 	return b.Class
 }
 
+func (b *BooleanObject) equal(e *BooleanObject) bool {
+	return b.Value == e.Value
+}
+
 var builtinBooleanMethods = []*BuiltInMethod{
 	{
 		Fn: func(receiver Object) builtinMethodBody {

--- a/vm/integer.go
+++ b/vm/integer.go
@@ -32,6 +32,10 @@ func (i *IntegerObject) returnClass() Class {
 	return i.Class
 }
 
+func (i *IntegerObject) equal(e *IntegerObject) bool {
+	return i.Value == e.Value
+}
+
 func initilaizeInteger(value int) *IntegerObject {
 	return &IntegerObject{Value: value, Class: integerClass}
 }

--- a/vm/string.go
+++ b/vm/string.go
@@ -36,6 +36,10 @@ func (s *StringObject) returnClass() Class {
 	return s.Class
 }
 
+func (s *StringObject) equal(e *StringObject) bool {
+	return s.Value == e.Value
+}
+
 var (
 	stringTable = make(map[string]*StringObject)
 )

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -459,6 +459,10 @@ func testArrayObject(t *testing.T, obj Object, expected *ArrayObject) bool {
 		return false
 	}
 
+	if len(result.Elements) != len(expected.Elements) {
+		t.Fatalf("Don't equals length of array. Expect %d, got=%d", len(expected.Elements), len(result.Elements))
+	}
+
 	for i := 0; i < len(result.Elements); i++ {
 		intObj, ok := expected.Elements[i].(*IntegerObject)
 		if ok {


### PR DESCRIPTION
New methods:
1) `at`
```
a = [1, "a", 10, 5]
a.at(0) #=> 1
```
2) `clear`
```
a = [1, "a", 10, 5]
a.clear
a #=> []
```

3) `concat`
```
a = [1, "a", 10, 5]
a.concat(["qwe", 1])
a #=> [1, "a", 10, 5, "qwe", 1]
```

4) `count`
```
a = [1, "a", 10, 5, 1]
a.count #=> 5

b = ["a", "b", "c", "d", "a", 2, "a"]
a.count("a") #=> 3

a = [1, 2, 3, 5, 1, 33, 4, 9, 0]
a.count do |i|
    i > 2
end
#=> 5
```

5) `rotate`
```
a = [1, "a", 10, 5, 1]
a.rotate #=> ["a", 10, 5, 1, 1]
a.rotate(3) #=> [5, 1, 1, "a", 10]
```